### PR TITLE
Fixes for compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,8 @@ dmypy.json
 *.aux
 *.pdf
 *.tex
+# Re-include header .tex file (manually created)
+!header.tex
 quarto/stan-getting-started_files/
 
 # Mac caches

--- a/makefile
+++ b/makefile
@@ -1,2 +1,5 @@
-stan-getting-started.pdf:  quarto/stan-getting-started.qmd
+quarto/stan-getting-started.html: quarto/stan-getting-started.qmd
 	quarto render quarto/stan-getting-started.qmd --to html --no-execute-daemon
+
+quarto/stan-getting-started.pdf:  quarto/stan-getting-started.qmd
+	quarto render quarto/stan-getting-started.qmd --to pdf

--- a/quarto/stan-getting-started.qmd
+++ b/quarto/stan-getting-started.qmd
@@ -5278,7 +5278,7 @@ plot1 = (pn.ggplot(df, pn.aes(x='n', y='cdf'))
     + pn.scale_x_continuous(limits=(1,13),
                             breaks=support, expand=(0, 0))
     + pn.ggtitle('cdf')
-    + pn.theme(strip_margin_x=5.0))
+    + pn.theme(strip_align_x=5.0))
 for n in range(0,12):
     plot1 += pn.geom_segment(pn.aes(x = n + 1,
                y = cdf_values[n], xend = n + 2 - 0.075,


### PR DESCRIPTION
This PR applies 3 changes to enable compilation as described in the `readme`.

1. Changed the `makefile` to update the default target to the html file that's actually getting generated. Prior to this change, `make` wasn't recognizing that the html output file had been created, and so would recreate it every time, regardless of change status. Also, the earlier version of the makefile referenced the pdf output but had the html-compilation command, which I assume was a mistake (now fixed).
2. PDF compilation is failing for me because an included header file, `header.tex`, is not present. I think this is due to the `.gitignore` line that bars `.tex` files as autogenerated C++ files, which means there's no `header.tex` in the repo. I've updated the `.gitignore` to add that file back (so hopefully it'll get picked up on a later commit and added to the repo).
3. Within the main document body, one of the figures uses a `plotnine` theme element called `strip_margin_x`. However, this element has been renamed to `strip_align_x` since at least plotnine v12 (the last tag with the old name was v10), so the code no longer builds when referring to the older version of the library. I updated the parameter name so it now works after `pip install`ing `plotnine`.